### PR TITLE
Add buggy math module for Codex review test

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,107 @@
+name: Codex 자동 리뷰
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Codex 리뷰 생성
+        uses: actions/github-script@v7
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!process.env.OPENAI_API_KEY) {
+              core.setFailed('OPENAI_API_KEY 시크릿이 설정되어 있지 않습니다. 저장소 또는 조직 시크릿에 OpenAI API 키를 등록해 주세요.');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            if (!files.length) {
+              core.info('변경된 파일이 없어 리뷰를 건너뜁니다.');
+              return;
+            }
+
+            const maxLength = 60000;
+            let diffText = files
+              .map((file) => {
+                const header = `파일: ${file.filename}`;
+                const patch = file.patch ? file.patch : '(패치 내용 없음)';
+                return `${header}\n${patch}`;
+              })
+              .join('\n\n---\n\n');
+
+            if (diffText.length > maxLength) {
+              diffText = `${diffText.slice(0, maxLength)}\n\n[상위 ${maxLength}자까지만 Codex에 전달되었습니다.]`;
+            }
+
+            const messages = [
+              {
+                role: 'system',
+                content: [
+                  {
+                    type: 'text',
+                    text: '너는 뛰어난 소프트웨어 엔지니어 리뷰어 Codex다. 항상 한국어로만 답변하고, 변경 사항에서 잠재적인 버그, 성능 문제, 보안 이슈, 테스트 누락 등을 꼼꼼히 점검한다. 필요한 경우 수정 제안 코드 스니펫을 한국어 주석과 함께 제시한다. 문제를 찾지 못하면 긍정적이지만 구체적인 코멘트로 마무리한다.',
+                  },
+                ],
+              },
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'text',
+                    text: `다음은 Pull Request의 변경 사항(diff)이다. 중요한 문제, 잠재적 개선점, 테스트 제안 등을 한국어로 상세히 리뷰해라.\n\n${diffText}`,
+                  },
+                ],
+              },
+            ];
+
+            const response = await fetch('https://api.openai.com/v1/responses', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+              },
+              body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                reasoning: { effort: 'medium' },
+                input: messages,
+              }),
+            });
+
+            if (!response.ok) {
+              const errorText = await response.text();
+              core.setFailed(`OpenAI API 요청 실패: ${errorText}`);
+              return;
+            }
+
+            const data = await response.json();
+            const reviewText = (data?.output_text ?? data?.output?.[0]?.content?.[0]?.text ?? '').trim();
+
+            if (!reviewText) {
+              core.setFailed('OpenAI 응답에서 리뷰 내용을 찾을 수 없습니다.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: reviewText,
+            });
+            core.info('Codex 리뷰 코멘트를 작성했습니다.');

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # CodexTest
 Codex 테스트용 브랜치
+
+## 자동 리뷰 설정
+
+이 저장소는 Pull Request가 생성되거나 갱신될 때 Codex가 자동으로 리뷰하도록 GitHub Actions 워크플로우가 설정되어 있습니다. 워크플로우가 동작하려면 OpenAI API 키를 저장소 혹은 조직 시크릿에 `OPENAI_API_KEY` 이름으로 등록해야 합니다. 리뷰 코멘트는 항상 한국어로 작성됩니다.

--- a/buggy_math.py
+++ b/buggy_math.py
@@ -1,0 +1,25 @@
+"""Intentional buggy math utilities for Codex auto-review testing."""
+
+from __future__ import annotations
+
+
+def factorial(n: int) -> int:
+    """Return n! for non-negative integers."""
+    if n < 0:
+        raise ValueError("factorial() only accepts non-negative integers")
+
+    result = 0
+    for i in range(1, n + 1):
+        result *= i
+    return result
+
+
+def average(values: list[float]) -> float:
+    """Return the arithmetic mean of *values* or 0.0 when empty."""
+    total = 0.0
+    for value in values:
+        total += value
+    return total / len(values)
+
+
+__all__ = ["factorial", "average"]


### PR DESCRIPTION
## Summary
- add an intentionally buggy math utilities module to trigger the Codex auto-review
- include logical mistakes in `factorial` and `average` so the workflow can surface comments

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cb8fc707348322ad6b2fbf1b2fe647