### PR TITLE
Update workflow to use input_text messages

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -55,7 +55,7 @@ jobs:
                 role: 'system',
                 content: [
                   {
-                    type: 'text',
+                    type: 'input_text',
                     text: '너는 뛰어난 소프트웨어 엔지니어 리뷰어 Codex다. 항상 한국어로만 답변하고, 변경 사항에서 잠재적인 버그, 성능 문제, 보안 이슈, 테스트 누락 등을 꼼꼼히 점검한다. 필요한 경우 수정 제안 코드 스니펫을 한국어 주석과 함께 제시한다. 문제를 찾지 못하면 긍정적이지만 구체적인 코멘트로 마무리한다.',
                   },
                 ],
@@ -64,7 +64,7 @@ jobs:
                 role: 'user',
                 content: [
                   {
-                    type: 'text',
+                    type: 'input_text',
                     text: `다음은 Pull Request의 변경 사항(diff)이다. 중요한 문제, 잠재적 개선점, 테스트 제안 등을 한국어로 상세히 리뷰해라.\n\n${diffText}`,
                   },
                 ],
@@ -91,7 +91,11 @@ jobs:
             }
 
             const data = await response.json();
-            const reviewText = (data?.output_text ?? data?.output?.[0]?.content?.[0]?.text ?? '').trim();
+            const outputContent = data?.output?.[0]?.content ?? [];
+            const textItem = outputContent.find((item) => item.type === 'output_text') ?? outputContent[0];
+            const textValue =
+              typeof textItem?.text === 'string' ? textItem.text : textItem?.text?.value;
+            const reviewText = (data?.output_text ?? textValue ?? '').trim();
 
             if (!reviewText) {
               core.setFailed('OpenAI 응답에서 리뷰 내용을 찾을 수 없습니다.');


### PR DESCRIPTION
## Summary
- switch Codex review workflow prompts to use the Responses API `input_text` message content type
- make response parsing resilient to structured `output_text` items when extracting the review comment

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codex-review.yml'); puts 'YAML valid'"

------
https://chatgpt.com/codex/tasks/task_b_68cb982ed8d0832285dedca64f277823