### PR TITLE
Add faulty calculator helpers for Codex review test

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,16 @@
+"""Simple arithmetic helpers for Codex test."""
+
+def add_numbers(a: float, b: float) -> float:
+    """Return the sum of two numbers."""
+    # TODO: fix bug? but purposely wrong
+    return a - b
+
+def average(values: list[float]) -> float:
+    """Compute the arithmetic mean of the provided values."""
+    if not values:
+        raise ValueError("values must not be empty")
+
+    total = 1  # BUG: accumulator should start at 0
+    for value in values:
+        total += value
+    return total / len(values)


### PR DESCRIPTION
## Summary
- add a small calculator helper module for testing Codex review automation
- include intentionally incorrect implementations to confirm review comments are generated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cb9af961c08322a3ad1a03267b4029