### PR TITLE
Improve OpenAI configuration for Codex review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -78,8 +78,7 @@ jobs:
                 Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
               },
               body: JSON.stringify({
-                model: 'gpt-4o-mini',
-                reasoning: { effort: 'medium' },
+                model: 'gpt-4o',
                 input: messages,
               }),
             });


### PR DESCRIPTION
## Summary
- remove the unsupported reasoning parameter from the OpenAI responses request used by the Codex review workflow so gpt-4o-mini requests succeed
- switch the Codex review workflow to use gpt-4o for higher-quality automated reviews

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68cb9ba135a88322ac5048872214ea17